### PR TITLE
Common Dockerfile for all architectures

### DIFF
--- a/base-docker-binary/Dockerfile
+++ b/base-docker-binary/Dockerfile
@@ -1,11 +1,9 @@
 FROM alpine:latest as base
 
-ARG PLATFORM=linux
-ARG ARCH=x86_64
 ARG DOCKER_VERSION=17.09.0-ce
 
 RUN apk --no-cache --update upgrade && apk --no-cache add ca-certificates wget && update-ca-certificates
-RUN wget -O docker-binaries.tgz https://download.docker.com/${PLATFORM}/static/stable/${ARCH}/docker-${DOCKER_VERSION}.tgz \
+RUN wget -O docker-binaries.tgz https://download.docker.com/$(uname -s | sed 's/Linux/linux/')/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz \
   && tar -xf docker-binaries.tgz
 
 FROM scratch


### PR DESCRIPTION
Use uname command to determine platform and architecture (for downloading docker), to enable non-x86 architectures. Also tested on s390x.